### PR TITLE
feat: add support of github actions to continiously track tests status

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,23 @@
+name: core-js-101
+
+on:
+  push:
+    branches:
+      - '*'
+
+jobs:
+  core-js-101:
+   runs-on: ubuntu-latest
+   steps:
+    - name: checkout sources
+      uses: actions/checkout@master
+    - name: setup node environment
+      uses: actions/setup-node@v1
+      with:
+        node-version: '10.x'
+    - name: install dependencies
+      run: npm install
+    - name: check styles
+      run: npm run lint
+    - name: run tests
+      run: npm run test


### PR DESCRIPTION
GitHub actions are now available for public repositories for free.
And you can integrate it with your task.

In current job node10 is configured and run tests for every commit/push.
This can help students and can became as additional verification step for this task.

[For example](https://github.com/aleksei-bulgak/core-js-101/actions?query=branch%3Apatch-1)