### PR TITLE
Change linebreak-style rule from error to warning

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,5 +16,6 @@ module.exports = {
     ecmaVersion: 2018,
   },
   rules: {
+    'linebreak-style': "warn"
   },
 };


### PR DESCRIPTION
Currently it prevents people with Windows machines to commit solutions.