### PR TITLE
fix: deleted double space in example

### DIFF
--- a/src/03-arrays-tasks.js
+++ b/src/03-arrays-tasks.js
@@ -48,8 +48,8 @@ function generateOdds(/* len */) {
  * @return {array}
  *
  * @example
- *    ['Ace', 10, true]  => ['Ace', 10, true,   'Ace', 10, true]
- *    [0, 1, 2, 3, 4, 5] => [0, 1, 2, 3, 4, 5,   0, 1, 2, 3, 4, 5]
+ *    ['Ace', 10, true]  => ['Ace', 10, true, 'Ace', 10, true]
+ *    [0, 1, 2, 3, 4, 5] => [0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5]
  *    [] => []
  */
 function doubleArray(/* arr */) {


### PR DESCRIPTION
I was doing this task and by my own inattention, based on the example in the problem, decided that the output arrays should be separated by a double space.
At first I thought it was an empty object or real problems instead of an element in the array.
After spending 10 minutes, I accidentally realized that my test passed without these spaces.

I suggest removing them =)