### PR TITLE
fix: correct test of insertItem()

### DIFF
--- a/test/03-arrays-tests.js
+++ b/test/03-arrays-tests.js
@@ -228,10 +228,10 @@ describe('03-arrays-tasks', () => {
         expected: ['x', 1, 'b', 'c'],
       },
     ].forEach((data) => {
-      tasks.insertItem(data.arr, data.item, data.index);
+      const actual = tasks.insertItem(data.arr, data.item, data.index);
       assert.deepEqual(
         data.expected,
-        data.arr,
+        actual,
       );
     });
   });


### PR DESCRIPTION
Found that a test for the function `insertItem()` was comparing an expected value with an initial value, not calculated value